### PR TITLE
Fix for Xcode 7 beta 5

### DIFF
--- a/Source/LogKit.swift
+++ b/Source/LogKit.swift
@@ -103,7 +103,7 @@ public struct LXLogEntry {
     public let logKitVersion: String
 
     /// The name of the source file from which the log entry was created.
-    public var fileName: String { return self.filePath.lastPathComponent }
+    public var fileName: String { return (self.filePath as NSString).lastPathComponent }
 
 }
 


### PR DESCRIPTION
`String` is no longer cast to `NSString` automatically.
