### PR TITLE
new endpoint LXManuallyRotatingFileEndpoint

### DIFF
--- a/Source/FileEndpoints.swift
+++ b/Source/FileEndpoints.swift
@@ -48,6 +48,9 @@ public let LXFileEndpointRotationCurrentURLKey:       String = "info.logkit.endp
 /// The value found at this key is the `NSURL` of the sender's next log file.
 public let LXFileEndpointRotationNextURLKey:          String = "info.logkit.endpoint.fileEndpoint.nextURL"
 
+/// This is a notification that can be posted to cause any `LXManuallyRotatingFileEndpoint` instances to rotate immediately
+public let LXFileEndpointCauseRotationKey:            String = "info.logkit.endpoint.fileEndpoint.rotate"
+
 
 /// The default file to use when logging: `log.txt`
 private let defaultLogFileURL: NSURL? = LK_DEFAULT_LOG_DIRECTORY?.URLByAppendingPathComponent("log.txt", isDirectory: false)
@@ -382,6 +385,8 @@ public class LXManuallyRotatingFileEndpoint: LXRotatingFileEndpoint {
         entryFormatter: LXEntryFormatter = LXEntryFormatter.standardFormatter()
     ) {
         super.init(baseURL: baseURL, numberOfFiles: numberOfFiles, maxFileSizeKiB: maxFileSizeKiB, minimumPriorityLevel: minimumPriorityLevel, dateFormatter: dateFormatter, entryFormatter: entryFormatter)
+        /// Listen for rotation notifications
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("rotate"), name: LXFileEndpointCauseRotationKey, object: nil)
     }
 
     /**

--- a/Source/FileEndpoints.swift
+++ b/Source/FileEndpoints.swift
@@ -39,6 +39,13 @@ This notification is send _after_ the rotation occurs, but _before_ any pending 
 */
 public let LXFileEndpointDidRotateFilesNotification:  String = "info.logkit.endpoint.fileEndpoint.didRotateFiles"
 
+/**
+This notification clients can post which will cause any `LXManuallyRotatingFileEndpoint` instances to rotate immediately.
+
+The notification's `object` and `userInfo` fields are ignored.
+*/
+public let LXFileEndpointCauseRotationNotification:   String = "info.logkit.endpoint.fileEndpoint.rotate"
+
 /// The value found at this key is the `NSURL` of the sender's previous log file.
 public let LXFileEndpointRotationPreviousURLKey:      String = "info.logkit.endpoint.fileEndpoint.previousURL"
 
@@ -47,9 +54,6 @@ public let LXFileEndpointRotationCurrentURLKey:       String = "info.logkit.endp
 
 /// The value found at this key is the `NSURL` of the sender's next log file.
 public let LXFileEndpointRotationNextURLKey:          String = "info.logkit.endpoint.fileEndpoint.nextURL"
-
-/// This is a notification that can be posted to cause any `LXManuallyRotatingFileEndpoint` instances to rotate immediately
-public let LXFileEndpointCauseRotationKey:            String = "info.logkit.endpoint.fileEndpoint.rotate"
 
 
 /// The default file to use when logging: `log.txt`
@@ -386,7 +390,11 @@ public class LXManuallyRotatingFileEndpoint: LXRotatingFileEndpoint {
     ) {
         super.init(baseURL: baseURL, numberOfFiles: numberOfFiles, maxFileSizeKiB: maxFileSizeKiB, minimumPriorityLevel: minimumPriorityLevel, dateFormatter: dateFormatter, entryFormatter: entryFormatter)
         /// Listen for rotation notifications
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("rotate"), name: LXFileEndpointCauseRotationKey, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "rotateNotification:", name: LXFileEndpointCauseRotationNotification, object: nil)
+    }
+    
+    @objc private func rotateNotification(notification: NSNotification){
+        rotate()
     }
 
     /**


### PR DESCRIPTION
Since @justinpawela you were so quick in helping me out, I figured I'd share my solution from #11. This adds a new file endpoint that functions the same as `LXRotatingFileEndpoint` with two differences:
- The file can be rotated manually, either with `.rotate()` or with a posted notification to `LXFileEndpointCauseRotationNotification`
- Providing a non-positive `maxFileSizeKiB` will cause it to never rotate based on file size, so that it is only rotated manually

I totally understand if you don't want to support another endpoint, and I'm quite happy to use my fork if you decide not to mainline it. 
